### PR TITLE
fix main loop bug

### DIFF
--- a/datatitan_site/data/scripts/generate_graphs.py
+++ b/datatitan_site/data/scripts/generate_graphs.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import mpld3
 from data.models import CovidDataClean, Country, Months, CovidDataMonthly


### PR DESCRIPTION
This PR resolves the main loop bug that caused the server to crash after creating several graphs.
The error was caused by matplotlib not running in the main loop (likely because the django server runs in the main loop) and was resolved by using adding `matplotlib.use("Agg")` after importing it. This makes matplotlib use a different backend which is more stable in this case. 
For more info on Matplotlib backends, refer to https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
